### PR TITLE
Large attraction image component creation

### DIFF
--- a/public/icons/left-caret-icon.svg
+++ b/public/icons/left-caret-icon.svg
@@ -1,0 +1,3 @@
+<svg width="8" height="12" viewBox="0 0 8 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6.5 11L1.5 6L6.5 1" stroke="#B8B8B8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/app/components/large-attraction-image.tsx
+++ b/src/app/components/large-attraction-image.tsx
@@ -1,0 +1,20 @@
+import SquaredButton from "./squared-button";
+import RoundedButton from "./rounded-button";
+
+const LargeAttractionImage = () => {
+  return (
+    <div className="relative">
+      <div className="absolute left-3 top-3">
+        <SquaredButton imageUrl="/icons/left-caret-icon.svg" />
+      </div>
+      <img
+        src="/images/landscape.jpg"
+        alt="Image of the attraction"
+        className="h-80 object-cover rounded-3xl"
+      />
+      <RoundedButton imageUrl="/icons/heart-lined.svg" />
+    </div>
+  );
+};
+
+export default LargeAttractionImage;


### PR DESCRIPTION
Assemble previous created components on a new one: a component displaying the image of the attraction as well as an option to return and an option to favorite the attraction.
![image](https://github.com/Nicog03/travel-app/assets/87248260/c52f0117-ccd8-4d6b-b1be-8453f5a74152)
